### PR TITLE
adds remote cert checking, and uses attachments

### DIFF
--- a/CheckYourSSeLf.rb
+++ b/CheckYourSSeLf.rb
@@ -1,32 +1,38 @@
 #!/usr/bin/env ruby
 
+# encoding: utf-8
+
 require 'bundler/setup'
 require 'aws-sdk-resources'
+require 'net/https'
 require 'openssl'
 require 'slack-notifier'
 require 'yaml'
+require 'json'
 
 class CheckYourSSeLf
   attr_reader :config, :slack
 
   def initialize
-    @config = YAML.load(File.read("config.yml"))
+    @config = YAML.load_file("config.yml")
 
     @slack = Slack::Notifier.new(config["slack_webhook_url"],
                                  username: config["slack_username"])
   end
 
   def check_yourself_before_you_wreck_yourself
-    message = slack_message(imminent_disasters)
-
     config["slack_channels"].each do |channel|
-      slack.ping(message, channel: channel, icon_emoji: config["slack_emoji"])
+      slack_message(imminent_disasters, channel, config["slack_emoji"])
     end
   end
 
   private
 
-  def certificate_names(iam_client)
+  def all_certificates
+    @all_certificates ||= (aws_certificates + remote_certificates)
+  end
+
+  def aws_certificate_names(iam_client)
     certificate_list = iam_client.list_server_certificates(max_items: config["aws_max_items"])
     certificate_metadata_list = certificate_list.server_certificate_metadata_list
 
@@ -35,11 +41,25 @@ class CheckYourSSeLf
     end
   end
 
-  def certificate_x509(certificate_name, iam_client)
-    certificate = iam_client.get_server_certificate(server_certificate_name: certificate_name)
-    certificate_body = certificate.server_certificate.certificate_body
+  def aws_certificates
+    @aws_certificates ||= config["aws_accounts"].collect do |account|
+      iam_client = Aws::IAM::Client.new(region: config["aws_default_region"],
+                                        access_key_id: account["aws_access_key_id"],
+                                        secret_access_key: account["aws_secret_access_key"])
 
-    OpenSSL::X509::Certificate.new(certificate_body)
+      aws_certificate_names(iam_client).collect do |certificate_name|
+        certificate = fetch_aws_certificate_x509(certificate_name, iam_client)
+        {
+          common_name: common_name(certificate),
+          days_remaining: days_remaining(certificate),
+          source: "AWS",
+          extra_info: {
+            iam_name: certificate_name,
+            account_name: account["name"]
+          }
+        }
+      end
+    end.flatten
   end
 
   def common_name(certificate)
@@ -62,60 +82,104 @@ class CheckYourSSeLf
     seconds_until_expiration / 60 / 60 / 24
   end
 
-  def expiration_output(reasons_to_panic)
-    output = <<-HEADER
-*The following SSL certificates are about to expire:*
+  def expiration_output(reasons_to_panic, channel, emote)
+    grouped_warnings = group_warnings(reasons_to_panic)
 
-```
-    HEADER
-
-    reasons_to_panic.each do |potential_crisis|
-      output << <<-DETAILS
-#{potential_crisis[:common_name]}
----
-  Days Remaining: #{potential_crisis[:days_remaining]}
-  IAM Name:       #{potential_crisis[:iam_name]}
-  AWS Account:    #{potential_crisis[:account_name]}
-
-      DETAILS
-    end
-
-    output << "```"
-  end
-
-  def expiring_certificates(account_name, iam_client)
-    certificate_names(iam_client).each_with_object([]) do |certificate_name, expirations|
-      certificate = certificate_x509(certificate_name, iam_client)
-
-      timeframe = days_remaining(certificate)
-
-      if timeframe < config["days_remaining_warning_threshold"]
-        expirations << { common_name: common_name(certificate),
-                         iam_name: certificate_name,
-                         days_remaining: timeframe,
-                         account_name: account_name }
+    attachments = []
+    grouped_warnings.each do |warning_level, records|
+      group_records(records).each do |record|
+        attachments << {
+          text: format_message(record),
+          color: warning_level,
+          mrkdwn_in: [
+            "text",
+            "pretext"
+          ]
+        }
       end
     end
+
+    slack.ping "*The following SSL certificates are about to expire:*", attachments: attachments,
+      channel: channel, icon_emoji: emote
+  end
+
+  def fetch_aws_certificate_x509(certificate_name, iam_client)
+    certificate = iam_client.get_server_certificate(server_certificate_name: certificate_name)
+    certificate_body = certificate.server_certificate.certificate_body
+
+    OpenSSL::X509::Certificate.new(certificate_body)
+  end
+
+  def group_warnings(warnings)
+    warnings.group_by { |disaster|
+      if disaster[:days_remaining] > config["medium_threshold"]
+        'good'
+      elsif disaster[:days_remaining] > config["low_threshold"]
+        'warning'
+      else
+        'danger'
+      end
+    }.sort_by { |k, v|
+      if k == "good"
+        3
+      elsif k == "warning"
+        2
+      else
+        1
+      end
+    }
+  end
+
+  def group_records(records)
+    records.sort {|a,b| a[:days_remaining] <=> b[:days_remaining]}
+  end
+
+  def format_message(potential_crisis)
+    <<-DETAILS
+*#{potential_crisis[:days_remaining]} Days* #{potential_crisis[:source]} Certificate, #{potential_crisis[:common_name]}, #{potential_crisis[:extra_info].values.flatten.join(', ')}
+    DETAILS
   end
 
   def imminent_disasters
-    config["aws_accounts"].each_with_object([]) do |account, utterly_doomed|
-      iam_client = Aws::IAM::Client.new(region: config["aws_default_region"],
-                                        access_key_id: account["aws_access_key_id"],
-                                        secret_access_key: account["aws_secret_access_key"])
-
-      expiring_account_certificates = expiring_certificates(account["name"], iam_client)
-
-      # Add this account's expiring certificates to the overall array.
-      utterly_doomed.concat(expiring_account_certificates)
+    all_certificates.select do |certificate|
+      certificate[:days_remaining] <= config["days_remaining_warning_threshold"]
     end
   end
 
-  def slack_message(reasons_to_panic)
+  def next_apocalypse
+    all_certificates.sort { |a,b| a[:days_remaining] <=> b[:days_remaining] }.first
+  end
+
+  def remote_certificates
+    @remote_certificates ||= config["remote_certs"].collect do |remote|
+      uri = URI.parse(remote["url"])
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      http.start do |h|
+        {
+          days_remaining: days_remaining(h.peer_cert),
+          source: "Remote",
+          common_name: remote["name"],
+          extra_info: {
+            url: remote["url"]
+          }
+        }
+      end
+    end.flatten
+  end
+
+  def slack_message(reasons_to_panic, channel, emote)
     if reasons_to_panic.size.zero?
-      "\\o/ No certificates are expiring within the next #{config["days_remaining_warning_threshold"]} days."
+      forgiving_message = <<-APOCALYPSE
+\\o/ No certificates are expiring within the next #{config["days_remaining_warning_threshold"]} days.
+
+Only #{next_apocalypse[:days_remaining]} days until the next certificate expires. /o\\
+      APOCALYPSE
+
+      slack.ping forgiving_message, channel: channel, icon_emoji: emote
     else
-      expiration_output(reasons_to_panic)
+      expiration_output(reasons_to_panic, channel, emote)
     end
   end
 end

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 CheckYourSSeLf
 ==============
-A friendly [Slack](https://slack.com/) bot that checks your Amazon AWS accounts for expiring SSL certificates.
+A friendly [Slack](https://slack.com/) bot that checks your Amazon AWS accounts, and remote urls for expiring SSL certificates.
 
 How does it work?
 -----------------
-* The bot retrieves a list of all IAM Server Certificates from each configured AWS account.
+* The bot retrieves a list of all IAM Server Certificates from each configured AWS account, and each remote url.
 * Every certificate is then parsed to see how many days are left until expiration.
 * Certificates that fall below the configured warning threshold will trigger an alert.
 * The results get posted to Slack.
@@ -12,23 +12,23 @@ How does it work?
 How do I use it?
 ----------------
 1. Clone this repository.
-1. Create a copy of the sample configuration file and modify it to suit your needs.
+2. Create a copy of the sample configuration file and modify it to suit your needs.
    * `cp config.yml.sample config.yml`
    * `text-editor-of-your-choice config.yml`
-1. Choose a home for the bot, and copy it there. Ruby and Bundler are the only requirements.
+3. Choose a home for the bot, and copy it there. Ruby and Bundler are the only requirements.
    * `ssh deploy@slackbot-server 'mkdir -p /opt/checkyoursself'`
    * `scp CheckYourSSeLf.rb config.yml Gemfile Gemfile.lock deploy@slackbot-server:/opt/checkyoursself`
-1. Install the bundle.
+4. Install the bundle.
    * `ssh deploy@slackbot-server 'cd /opt/checkyoursself && bundle install --deployment'`
-1. Run the bot once to make sure everything is working properly.
+5. Run the bot once to make sure everything is working properly.
    * `ssh deploy@slackbot-server 'cd /opt/checkyoursself && ruby CheckYourSSeLf.rb'`
-1. Set up a crontab entry to run the bot on a regular basis.
+6. Set up a crontab entry to run the bot on a regular basis.
    * `ssh deploy@slackbot-server`
    * `crontab -e`
      * A line like this would make the bot run once a day at 16:05:
 
        `5 16 * * * cd /opt/checkyoursself && ruby CheckYourSSeLf.rb`
-1. That's it. No more surprises!
+7. That's it. No more surprises!
 
 LICENSE
 -------

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -2,9 +2,9 @@
 # Warnings will be displayed when the number of days remaining before
 # a certificate expires is less than this value.
 days_remaining_warning_threshold: 31
-# The threshold in which to turn announcements "yellow" for warning.
+# The threshold at which to turn announcements "yellow" for warning.
 medium_threshold: 20
-# The threshold in which to turn announcements "red" for critical.
+# The threshold at which to turn announcements "red" for critical.
 low_threshold: 10
 
 # AWS Configuration
@@ -58,8 +58,8 @@ slack_channels:
   - "#zerocool"
 
 remote_certs:
-  - name: "Razer&Blade"
-    url: "https://razer.blade.com"
+  - name: "Razor&Blade"
+    url: "https://razor.blade.com"
 
 # Emoji that will be displayed as the bot's avatar.
 slack_emoji: ":lock:"

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -2,7 +2,10 @@
 # Warnings will be displayed when the number of days remaining before
 # a certificate expires is less than this value.
 days_remaining_warning_threshold: 31
-
+# The threshold in which to turn announcements "yellow" for warning.
+medium_threshold: 20
+# The threshold in which to turn announcements "red" for critical.
+low_threshold: 10
 
 # AWS Configuration
 # ---
@@ -53,6 +56,10 @@ slack_channels:
   - "#hacktheplanet"
   - "#ughhardcopy"
   - "#zerocool"
+
+remote_certs:
+  - name: "Razer&Blade"
+    url: "https://razer.blade.com"
 
 # Emoji that will be displayed as the bot's avatar.
 slack_emoji: ":lock:"


### PR DESCRIPTION
this upgrades CheckYourSSeLf to do two new things.
1. First CheckYourSSeLf can now check remote urls for expiring certs.
   Because maybe not all of your certificates are in AWS, and that's okay.
   Maybe you just wanna see if something crazy happens and google lets
   their cert expire.
2. CheckYourSSeLf also now uses attachements. This makes the output
   a lot more easier to read in the long run, and can quickly draw attetion
   to the ones in danger with colors.
